### PR TITLE
lilyglyphs-example.tex: Correct command name

### DIFF
--- a/documentation/lilyglyphs-example.tex
+++ b/documentation/lilyglyphs-example.tex
@@ -66,7 +66,7 @@ With the new package \lilyglyphs{} you can easily insert the notational elements
 \footnote{\url{http://www.lilypond.org}}
 engraving software in your text documents.
 Accidentals like \flat{} or \sharp, but also articulation scripts (\hspace{.65ex}\fermata{}) and time signatures such as \lilyTimeCHalf{} or \lilyTimeSignature{5\,+\,7}{8} are readily available.
-But you can also insert arbitrary notational constructs like this mockup example \fancyExample{} into your text or even make scanned images available as “characters”.
+But you can also insert arbitrary notational constructs like this mockup example \lilyFancyExample{} into your text or even make scanned images available as “characters”.
 This package may greatly extend your typographical options when authoring or typesetting critical reports, analytical texts or teaching/exam material.
 
 One thing that sets \lilyglyphs{} apart from other solutions I had investigated is that one isn't restricted to a set of predefined symbols but is able to print \emph{any notation} that can be realized with LilyPond. 


### PR DESCRIPTION
\fancyExample should be \lilyFancyExample.
