### PR TITLE
run 2to3 on Python scripts

### DIFF
--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -55,9 +55,9 @@ manifest = []
 def main():
     
     if os.path.exists('deploy'):
-        overwrite = raw_input('deploy directory exists. Overwrite? ')
+        overwrite = input('deploy directory exists. Overwrite? ')
         if overwrite != 'y':
-            print 'Aborted'
+            print('Aborted')
             sys.exit(1)
         shutil.rmtree('deploy')
     os.mkdir('deploy')
@@ -65,7 +65,7 @@ def main():
     
     # now we're guaranteed to have an empty 'deploy/lilyglyphs' directory
     
-    print 'Copying files:'
+    print('Copying files:')
     # copy individual files from the root directory
     cp_root()
     # copy complete directories to their corresponding dest
@@ -140,12 +140,12 @@ def cp_folder(src, dest = None):
     global manifest
     if not dest:
         dest = src
-    print '-', src
+    print('-', src)
     shutil.copytree(src, dir_deploy + '/' + dest)
     append_manifest(src, dest)
     
 def cp_root():
-    print '- root'
+    print('- root')
     f = []
     f.append('CHANGES.md')
     f.append('INSTALL')
@@ -153,7 +153,7 @@ def cp_root():
     copy_files(f, '')
 
 def cp_scripts():
-    print '- scripts'
+    print('- scripts')
     os.mkdir(dir_deploy + '/bin')
     os.mkdir(dir_deploy + '/lib')
     for file in os.listdir('scripts'):
@@ -165,7 +165,7 @@ def cp_scripts():
             manifest.append('/lib/' + file)
     
 def lg_private():
-    print '- lilyglyphs_private'
+    print('- lilyglyphs_private')
     zip = zipfile.ZipFile(dir_deploy + '/documentation/lilyglyphs_private.zip', 'w')
     for root, dirs, files in os.walk('lilyglyphs_private'):
         for file in files:
@@ -216,15 +216,15 @@ if __name__ == "__main__":
         for part in version_parts:
             int(part)
     except:
-        print 'Malformed version argument:', version
-        print 'Use three integers separated by dots'
+        print('Malformed version argument:', version)
+        print('Use three integers separated by dots')
         sys.exit(1)
     
-    print 'Preparing lilyglyphs deployment', version + '.'
-    print 'CWD is', os.getcwd()
-    print 'This should be the root of lilyglyphs.'
-    print 'This script will not work on Windows.'
-    check = raw_input('Proceed (y/..)? ')
+    print('Preparing lilyglyphs deployment', version + '.')
+    print('CWD is', os.getcwd())
+    print('This should be the root of lilyglyphs.')
+    print('This script will not work on Windows.')
+    check = input('Proceed (y/..)? ')
     if check != 'y':
         sys.exit(1)
     

--- a/scripts/lily-glyph-commands.py
+++ b/scripts/lily-glyph-commands.py
@@ -80,10 +80,10 @@ def read_entries():
         if not len(line):
             # skip if cmd and glyph haven't been filled both
             if not (entry['cmd'] and entry['element']):
-                print 'Skip malformed entry \'' + entry['cmd'] + '\'. Please check input file'
+                print('Skip malformed entry \'' + entry['cmd'] + '\'. Please check input file')
                 reset_entry()
             else:
-                print 'Read entry \'' + entry['cmd'] + '\''
+                print('Read entry \'' + entry['cmd'] + '\'')
                 lg.in_cmds[entry['cmd']] = {}
                 lg.in_cmds[entry['cmd']]['element'] = entry['element']
                 lg.in_cmds[entry['cmd']]['type'] = entry['type']
@@ -110,13 +110,13 @@ def read_entries():
 
     
 def usage():
-    print 'genGlyphCommands.py'
-    print 'is part of the lilyglyphs package'
-    print ''
-    print 'Usage:'
-    print 'Pass the name (without path) of an input definitions file'
-    print '(this has to be located in the /stash_new_commands directory.'
-    print 'Please refer to the manual (documentation/lilyglyphs.pdf).'
+    print('genGlyphCommands.py')
+    print('is part of the lilyglyphs package')
+    print('')
+    print('Usage:')
+    print('Pass the name (without path) of an input definitions file')
+    print('(this has to be located in the /stash_new_commands directory.')
+    print('Please refer to the manual (documentation/lilyglyphs.pdf).')
 
 # ####################################
 # Finally launch the program

--- a/scripts/lily-image-commands.py
+++ b/scripts/lily-image-commands.py
@@ -63,35 +63,35 @@ lily_src_score = """
 
 def main():
     """Do the actual work of the script"""
-    print ''
-    print 'buildglyphimages.py,'
-    print 'Part of lilyglyphs.'
-    print ''
+    print('')
+    print('buildglyphimages.py,')
+    print('Part of lilyglyphs.')
+    print('')
     
     # set CWD and ensure the necessary subdirs are present
     check_paths()
-    print ''
+    print('')
 
     # load and parse input file
     lg.read_input_file(in_file)
     read_entries()
-    print ''
+    print('')
 
     # generate LilyPond source files for each command
     # and compile them
     write_lily_src_files()
-    print ''
+    print('')
     lg.compile_lily_files()
-    print ''
+    print('')
     
     # remove intermediate files and move pdfs to pdf directory
     lg.cleanup_lily_files()
-    print ''
+    print('')
     
     # generate latex commands and example code
     # and write them to the output file
     lg.generate_latex_commands()
-    print ''
+    print('')
     write_latex_file()
 
     
@@ -127,11 +127,11 @@ rais = ''
 
 def read_entries():
     """Parses the input source file and extracts glyph entries"""
-    print 'Read entries of LilyPond commands:'
+    print('Read entries of LilyPond commands:')
     for i in range(len(lg.definitions_file)):
         if '%%lilyglyphs' in lg.definitions_file[i]:
             i = read_entry(i)
-    print lg.lily_files
+    print(lg.lily_files)
 
 def read_entry(i):
     """Reads a single glyph entry from the input file and stores it
@@ -165,11 +165,11 @@ def read_entry(i):
     # read command name
     line = lg.definitions_file[i].strip()
     cmd_name = line[: line.find('=') - 1]
-    print '- ' + cmd_name,
+    print('- ' + cmd_name, end=' ')
     if is_protected:
-        print '(protected and skipped)'
+        print('(protected and skipped)')
     else:
-        print '' #(for line break only)
+        print('') #(for line break only)
 
     # read actual command until we find a line the begins with a closing curly bracket
     i += 1
@@ -193,7 +193,7 @@ def read_entry(i):
 
 
 def usage():
-    print """buildglyphimages. Part of the lilyglyphs package.
+    print("""buildglyphimages. Part of the lilyglyphs package.
     Parses a template file, creates
     single .ly files from it, uses LilyPond to create single glyph
     pdf files and set up template files to be used in LaTeX.
@@ -204,7 +204,7 @@ def usage():
     For detailed instructions refer to the manual.
     Usage:
     buildglyphimages.py in-file-name.
-    """
+    """)
 
 def write_file_info(name, fout):
     """Formats file specific information for the lilyPond source file"""
@@ -225,22 +225,22 @@ def write_file_info(name, fout):
 
 def write_latex_file():
     """Composes LaTeX file and writes it to disk"""
-    print 'Generate LaTeX file'
-    print lg.dir_cmd, in_basename
+    print('Generate LaTeX file')
+    print(lg.dir_cmd, in_basename)
     lg.write_latex_file(os.path.join(os.getcwd(), lg.dir_cmd,  in_basename + '.tex'))
 
 def write_lily_src_files():
     """Generates one .ly file for each found new command"""
     skip_cmds = []
-    print 'Write .ly files for each entry:'
+    print('Write .ly files for each entry:')
     for cmd_name in lg.in_cmds:
-        print '- ' + cmd_name
+        print('- ' + cmd_name)
         gen_src_name = os.path.join(lg.dir_lysrc, cmd_filename(cmd_name) + '.ly')
         # handle existing commands
         if os.path.exists(gen_src_name):
             action = ''
             while not (action == 'Y' or action == 'N'):
-                action = raw_input('already present. Overwrite (y/n)? ')
+                action = input('already present. Overwrite (y/n)? ')
                 action = action.upper()
             if action == 'N':
                 skip_cmds.append(cmd_name)
@@ -281,7 +281,7 @@ def write_lily_src_files():
         fout.close()
     
     # remove skipped commands from in_cmds
-    print skip_cmds
+    print(skip_cmds)
     for cmd_name in skip_cmds:
         del lg.in_cmds[cmd_name]
         lg.lily_files.remove(cmd_filename(cmd_name))
@@ -314,7 +314,7 @@ if __name__ == "__main__":
     in_path, in_filename = os.path.split(in_file)
     in_path = os.path.normpath(in_path)
     if not (('lilyglyphs' in in_path) and (in_path.endswith('definitions'))):
-        print 'File in the wrong location: ' + in_path
+        print('File in the wrong location: ' + in_path)
         usage()
         sys.exit(2)
     in_basename, in_ext = os.path.splitext(in_filename)

--- a/scripts/lily-rebuild-pdfs.py
+++ b/scripts/lily-rebuild-pdfs.py
@@ -54,9 +54,9 @@ import os, sys, subprocess, argparse, lilyglyphs_common as lg
 
 def main():
     """Main walk through the program"""
-    print 'rebuild-pdfs.py'
-    print 'regenerate all pdf images that are not present (anymore)'
-    print ''
+    print('rebuild-pdfs.py')
+    print('regenerate all pdf images that are not present (anymore)')
+    print('')
     
     # Check if we are in a legal CWD and ensure a PDF subdir is present
     check_paths()
@@ -66,14 +66,14 @@ def main():
 
     # is there anything to be done at all?
     if len(src_files) == 0:
-        print ''
-        print 'No image files missing, nothing to be done.'
-        print 'If you want to re-create pdfs, then delete them first'
+        print('')
+        print('No image files missing, nothing to be done.')
+        print('If you want to re-create pdfs, then delete them first')
         sys.exit(0)
-    print ''
-    print 'Found ' + str(len(src_files)) + ' missing file(s).'
+    print('')
+    print('Found ' + str(len(src_files)) + ' missing file(s).')
     for cmd in src_files:
-        print '- ' + cmd
+        print('- ' + cmd)
 
     # compile all LilyPond files without matching pdf
     lg.lily_files = src_files
@@ -86,7 +86,7 @@ def check_missing_pdfs():
     """Compares the list of LilyPond source and resulting PDF files.
        Returns a list of LilyPond source file basenames 
        which don't have a corresponding PDF file"""
-    print 'Reading file lists, counting missing pdf files'
+    print('Reading file lists, counting missing pdf files')
     
     # read existing .pdf files in lg.dir_pdfs
     img_files = []
@@ -114,21 +114,21 @@ def check_paths():
     """Checks if we're in the right CWD
        and makes sure that there is a pdf output directory available"""
 
-    print 'Checking directories ...'
+    print('Checking directories ...')
     
     # check the presence of the necessary subdirectories
     ls = os.listdir('.')
     if not 'generated_src' in ls:
-        print 'No LilyPond source files directory found.'
-        print 'Sorry, there is something wrong :-('
-        print 'Current working directory is: ' + os.getcwd()
-        print 'Please consult the manual.'
+        print('No LilyPond source files directory found.')
+        print('Sorry, there is something wrong :-(')
+        print('Current working directory is: ' + os.getcwd())
+        print('Please consult the manual.')
         sys.exit(2)
     if not 'pdfs' in ls:
         os.mkdir('pdfs')
     
-    print '... done'
-    print ''
+    print('... done')
+    print('')
 
 
 # ####################################

--- a/scripts/lilyglyphs_common.py
+++ b/scripts/lilyglyphs_common.py
@@ -232,7 +232,7 @@ def cleanup_lily_files():
     """Removes unneccessary files from LilyPond compilation,
     rename and remove the preview PDF files to the right directory."""
 
-    print 'Clean up directories'
+    print('Clean up directories')
     
     # iterate through dir_lysrc
     os.chdir(dir_lysrc)
@@ -255,7 +255,7 @@ def cleanup_lily_files():
     
 def compile_lily_files():
     """Compiles LilyPond files to """
-    print 'Compile with LilyPond:'
+    print('Compile with LilyPond:')
     for file in lily_files:
         args = []
         args.append("lilypond")
@@ -265,7 +265,7 @@ def compile_lily_files():
         args.append("-dno-point-and-click")
         args.append(os.path.join(dir_lysrc, file + ".ly"))
         subprocess.call(args)
-        print ''
+        print('')
 
 def generate_latex_commands():
     """Generates the templates for the commands in a new LaTeX file.
@@ -308,12 +308,12 @@ def read_input_file(in_file):
     
     in_file = os.path.normpath(in_file)
 
-    print 'Read input file ' + in_file
+    print('Read input file ' + in_file)
     
     # check for existence of input file
     if not os.path.exists(in_file):
-                    print 'File ' + in_file + ' not found.'
-                    print 'Please specify an input file'
+                    print('File ' + in_file + ' not found.')
+                    print('Please specify an input file')
                     sys.exit(2)
 
     fin = open(in_file,  'r')
@@ -336,7 +336,7 @@ def write_latex_file(file_name):
     fout.write(latexfile_start_comment.replace('SCRIPT_NAME', script_name()))
 
     # write out command definitions
-    sorted_cmds = sorted(latex_cmds.iterkeys())
+    sorted_cmds = sorted(latex_cmds.keys())
     for cmd_name in sorted_cmds:
         for line in latex_cmds[cmd_name]['cmd']:
             fout.write(line)


### PR DESCRIPTION
I gave 2to3 a try.
It changed the print command syntax, replaced raw_input with input and iterkeys with keys; all changes are correct.
I tested `lily_glyph_command.py` on the example in [Extending lilyglyphs (Part 1)](http://lilypondblog.org/2013/09/extending-lilyglyphs-part-1/) and it seems to work correctly.
I haven't tested the other scripts.

This PR may close #101.